### PR TITLE
Rewrite command system & cleanup

### DIFF
--- a/src/main/java/nl/finnt730/AliasCommand.java
+++ b/src/main/java/nl/finnt730/AliasCommand.java
@@ -1,11 +1,7 @@
 package nl.finnt730;
 
-import haxe.root.Array;
 import haxe.root.JsonStructureLib;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
-
-import java.util.function.Consumer;
 
 public final class AliasCommand extends ReservedCommand {
     private static final String USAGE_HINT = "Usage: !alias <existing_command> <new_alias>";
@@ -23,7 +19,7 @@ public final class AliasCommand extends ReservedCommand {
         String newAlias = parts[2];
 
         // File is arbiter of truth so I guess it's fine to do IO every time.
-        var command = JsonStructureLib.createReader().readFile("commands/" + existingCommandName + ".json");
+        var command = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, existingCommandName));
         if (command == null || command.getString("name", "_null").equals("_null")) {
             event.getChannel().sendMessage("Command " + existingCommandName + " not found!").queue();
             return;
@@ -44,7 +40,7 @@ public final class AliasCommand extends ReservedCommand {
                 .addStringArrayField("aliases", aliases)
                 .build();
 
-        JsonStructureLib.writeJsonFile(updatedCommand, "commands/" + existingCommandName + ".json", null);
+        JsonStructureLib.writeJsonFile(updatedCommand, String.format(Global.COMMANDS_LOCATION, existingCommandName), null);
         event.getChannel().sendMessage("Alias " + newAlias + " added to command " + existingCommandName + "!").queue();
     }
 }

--- a/src/main/java/nl/finnt730/AliasCommand.java
+++ b/src/main/java/nl/finnt730/AliasCommand.java
@@ -15,11 +15,11 @@ public final class AliasCommand extends ReservedCommand {
             return;
         }
 
-        String existingCommandName = parts[1];
-        String newAlias = parts[2];
+        String existingCommandName = parts[0];
+        String newAlias = parts[1];
 
         // File is arbiter of truth so I guess it's fine to do IO every time.
-        var command = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, existingCommandName));
+        var command = JsonStructureLib.createReader().readFile(Global.commandOf(existingCommandName));
         if (command == null || command.getString("name", "_null").equals("_null")) {
             event.getChannel().sendMessage("Command " + existingCommandName + " not found!").queue();
             return;
@@ -40,7 +40,7 @@ public final class AliasCommand extends ReservedCommand {
                 .addStringArrayField("aliases", aliases)
                 .build();
 
-        JsonStructureLib.writeJsonFile(updatedCommand, String.format(Global.COMMANDS_LOCATION, existingCommandName), null);
+        JsonStructureLib.writeJsonFile(updatedCommand, Global.commandOf(existingCommandName), null);
         event.getChannel().sendMessage("Alias " + newAlias + " added to command " + existingCommandName + "!").queue();
     }
 }

--- a/src/main/java/nl/finnt730/AliasCommand.java
+++ b/src/main/java/nl/finnt730/AliasCommand.java
@@ -5,44 +5,46 @@ import haxe.root.JsonStructureLib;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
-public final class AliasCommand extends ListenerAdapter {
+import java.util.function.Consumer;
+
+public final class AliasCommand extends ReservedCommand {
+    private static final String USAGE_HINT = "Usage: !alias <existing_command> <new_alias>";
+    public AliasCommand() {}
 
     @Override
-    public void onMessageReceived(MessageReceivedEvent event) {
-        String rawMessage = event.getMessage().getContentRaw();
-        if (rawMessage.startsWith("!alias")) {
-            String[] parts = rawMessage.split(" ");
-            if(parts.length < 3) {
-                event.getChannel().sendMessage("Usage: !alias <existing_command> <new_alias>").queue();
-                return;
-            }
-
-            String existingCommandName = parts[1];
-            String newAlias = parts[2];
-
-            var command = JsonStructureLib.createReader().readFile("commands/" + existingCommandName + ".json");
-            if (command == null || command.getString("name", "_null").equals("_null")) {
-                event.getChannel().sendMessage("Command " + existingCommandName + " not found!").queue();
-                return;
-            }
-
-            var aliases = command.getStringArray("aliases");
-            if (aliases.contains(newAlias)) {
-                event.getChannel().sendMessage("Alias " + newAlias + " already exists for command " + existingCommandName + "!").queue();
-                return;
-            }
-
-            aliases.push(newAlias);
-            var builder = JsonStructureLib.createObjectBuilder();
-            var updatedCommand = builder
-                    .addStringField("name", command.getString("name", ""))
-                    .addStringField("description", command.getString("description", ""))
-                    .addStringField("data", command.getString("data", ""))
-                    .addStringArrayField("aliases", aliases)
-                    .build();
-
-            JsonStructureLib.writeJsonFile(updatedCommand, "commands/" + existingCommandName + ".json", null);
-            event.getChannel().sendMessage("Alias " + newAlias + " added to command " + existingCommandName + "!").queue();
+    public void handle(MessageReceivedEvent event, String invoker, String commandContents) {
+        var parts = commandContents.split(" ");
+        if(parts.length < 2) {
+            event.getChannel().sendMessage(USAGE_HINT).queue();
+            return;
         }
+
+        String existingCommandName = parts[1];
+        String newAlias = parts[2];
+
+        // File is arbiter of truth so I guess it's fine to do IO every time.
+        var command = JsonStructureLib.createReader().readFile("commands/" + existingCommandName + ".json");
+        if (command == null || command.getString("name", "_null").equals("_null")) {
+            event.getChannel().sendMessage("Command " + existingCommandName + " not found!").queue();
+            return;
+        }
+
+        var aliases = command.getStringArray("aliases");
+        if (aliases.contains(newAlias)) {
+            event.getChannel().sendMessage("Alias " + newAlias + " already exists for command " + existingCommandName + "!").queue();
+            return;
+        }
+
+        aliases.push(newAlias);
+        var builder = JsonStructureLib.createObjectBuilder();
+        var updatedCommand = builder
+                .addStringField("name", command.getString("name", ""))
+                .addStringField("description", command.getString("description", ""))
+                .addStringField("data", command.getString("data", ""))
+                .addStringArrayField("aliases", aliases)
+                .build();
+
+        JsonStructureLib.writeJsonFile(updatedCommand, "commands/" + existingCommandName + ".json", null);
+        event.getChannel().sendMessage("Alias " + newAlias + " added to command " + existingCommandName + "!").queue();
     }
 }

--- a/src/main/java/nl/finnt730/Command.java
+++ b/src/main/java/nl/finnt730/Command.java
@@ -1,0 +1,8 @@
+package nl.finnt730;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+public abstract class Command {
+    public Command() {}
+    public abstract void handle(MessageReceivedEvent event, String invoker, String commandContents);
+}

--- a/src/main/java/nl/finnt730/CommandCache.java
+++ b/src/main/java/nl/finnt730/CommandCache.java
@@ -6,8 +6,7 @@ import java.util.*;
 
 public class CommandCache {
     private static final Map<String, Command> cache = new HashMap<>();
-    private static final Map<String, Set<Character>> userDefinedPrefixes = new HashMap<>();
-    private static final char DEFAULT_PREFIX = '!';
+    private static final String DEFAULT_PREFIX = "!";
 
     // Init reserved commands
     static {
@@ -17,25 +16,15 @@ public class CommandCache {
         cache.put("description", new DescriptionCommand());
     }
     public static CommandContext getOrDefault(String user, String rawContent) {
-        // Check if user has any additional prefixes.
-        var prefixes = userDefinedPrefixes.get(user);
-        if (prefixes == null) {
-            prefixes = new HashSet<>();
-            prefixes.add(DEFAULT_PREFIX);
-            userDefinedPrefixes.put(user, prefixes);
-        }
-
         // Parse out the actual command
         String actualCommand = null;
         String additionalData = null;
-        for (char prefix : prefixes) {
-            if (rawContent.charAt(0) == prefix) {
-                var temp = rawContent.substring(1).split(" ");
-                actualCommand = temp[0];
-                additionalData = rawContent.substring(actualCommand.length() + 1).trim();
-                break;
-            }
+        if (rawContent.startsWith(DEFAULT_PREFIX)) {
+            var temp = rawContent.substring(1).split(" ");
+            actualCommand = temp[0];
+            additionalData = rawContent.substring(actualCommand.length() + 1).trim();
         }
+
         if (actualCommand == null) return CommandContext.NONE;
         if (cache.containsKey(actualCommand)) return new CommandContext(cache.get(actualCommand), additionalData);
 

--- a/src/main/java/nl/finnt730/CommandCache.java
+++ b/src/main/java/nl/finnt730/CommandCache.java
@@ -1,0 +1,76 @@
+package nl.finnt730;
+
+import haxe.root.JsonStructureLib;
+
+import java.util.*;
+
+public class CommandCache {
+    private static final Map<String, Command> cache = new HashMap<>();
+    private static final Map<String, Set<Character>> userDefinedPrefixes = new HashMap<>();
+    private static final char DEFAULT_PREFIX = '!';
+
+    // Init reserved commands
+    static {
+        cache.put("register", new RegisterNewCommand());
+        cache.put("alias", new AliasCommand());
+        cache.put("delete", new DeleteCommand());
+        cache.put("description", new DescriptionCommand());
+    }
+    public static CommandContext getOrDefault(String user, String rawContent) {
+        // Check if user has any additional prefixes.
+        var prefixes = userDefinedPrefixes.get(user);
+        if (prefixes == null) {
+            prefixes = new HashSet<>();
+            prefixes.add(DEFAULT_PREFIX);
+            userDefinedPrefixes.put(user, prefixes);
+        }
+
+        // Parse out the actual command
+        String actualCommand = null;
+        String additionalData = null;
+        for (char prefix : prefixes) {
+            if (rawContent.charAt(0) == prefix) {
+                var temp = rawContent.substring(1).split(" ");
+                actualCommand = temp[0];
+                additionalData = rawContent.substring(actualCommand.length() + 1).trim();
+                break;
+            }
+        }
+        if (actualCommand == null) return CommandContext.NONE;
+        if (cache.containsKey(actualCommand)) return new CommandContext(cache.get(actualCommand), additionalData);
+
+        CommandContext result = null;
+        // Get if not in cache.
+        try {
+            var cmdJson = JsonStructureLib.createReader().readFile("commands/" + actualCommand + ".json");
+            if (cmdJson != null && cmdJson.getString("name", "_null").equals(actualCommand)) {
+                String data = cmdJson.getString("data", "");
+                // todo will need adaptation for things that aren't EchoCommands, but atm everything is... so.... :)
+                result = new CommandContext(new EchoCommand(data), null);
+            }
+            // Find alias if present
+            var files = new java.io.File("commands").listFiles((dir, name) -> name.endsWith(".json"));
+            if (files != null) {
+                for (var file : files) {
+                    var cmd = JsonStructureLib.createReader().readFile(file.getPath());
+                    var aliases = cmd.getStringArray("aliases");
+                    if (aliases.contains(actualCommand)) {
+                        String data = cmd.getString("data", "");
+                        // todo same here
+                        result = new CommandContext(new EchoCommand(data), null);
+                    }
+                }
+            }
+        } catch (Exception ignored) {} // if finn is ignoring exceptions then so will I
+        if (result != null) {
+            cache.put(actualCommand, result.command());
+            return result;
+        }
+        return CommandContext.NOT_FOUND;
+    }
+
+
+    public static void invalidateOnUpdate(String command) {
+        cache.remove(command);
+    }
+}

--- a/src/main/java/nl/finnt730/CommandCache.java
+++ b/src/main/java/nl/finnt730/CommandCache.java
@@ -31,12 +31,14 @@ public class CommandCache {
         CommandContext result = null;
         // Get if not in cache.
         try {
-            var cmdJson = JsonStructureLib.createReader().readFile("commands/" + actualCommand + ".json");
+            var cmdJson = JsonStructureLib.createReader().readFile(Global.commandOf(actualCommand));
             if (cmdJson != null && cmdJson.getString("name", "_null").equals(actualCommand)) {
                 String data = cmdJson.getString("data", "");
                 // todo will need adaptation for things that aren't EchoCommands, but atm everything is... so.... :)
                 result = new CommandContext(new EchoCommand(data), null);
             }
+        } catch (Exception ignored) {} // if finn is ignoring exceptions then so will I
+        try {
             // Find alias if present
             var files = new java.io.File("commands").listFiles((dir, name) -> name.endsWith(".json"));
             if (files != null) {
@@ -50,7 +52,7 @@ public class CommandCache {
                     }
                 }
             }
-        } catch (Exception ignored) {} // if finn is ignoring exceptions then so will I
+        } catch (Exception ignored) {}
         if (result != null) {
             cache.put(actualCommand, result.command());
             return result;

--- a/src/main/java/nl/finnt730/CommandContext.java
+++ b/src/main/java/nl/finnt730/CommandContext.java
@@ -1,0 +1,6 @@
+package nl.finnt730;
+
+public record CommandContext(Command command, String additionalData) {
+    public static final CommandContext NONE = new CommandContext(null, null);
+    public static final CommandContext NOT_FOUND = new CommandContext(null, null);
+}

--- a/src/main/java/nl/finnt730/DeleteCommand.java
+++ b/src/main/java/nl/finnt730/DeleteCommand.java
@@ -8,60 +8,59 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import java.io.File;
 import java.util.Objects;
 
-public final class DeleteCommand extends ListenerAdapter {
+public final class DeleteCommand extends ReservedCommand {
 
     @Override
-    public void onMessageReceived(MessageReceivedEvent event) {
+    public void handle(MessageReceivedEvent event, String invoker, String commandContents) {
         String rawMessage = event.getMessage().getContentRaw();
-        if (rawMessage.startsWith("!delete")) {
-            String command = rawMessage.substring(1).split(" ", 2)[0];
-            String messageContent = rawMessage.substring(command.length() + 2);
+        String command = rawMessage.substring(1).split(" ", 2)[0];
+        String messageContent = rawMessage.substring(command.length() + 2);
 
-            if (command.equalsIgnoreCase("delete")) {
-                // Check if user has admin or manage server permissions
+        if (command.equalsIgnoreCase("delete")) {
+            // Check if user has admin or manage server permissions
 //                if (!Objects.requireNonNull(event.getMember()).hasPermission(Permission.ADMINISTRATOR) &&
 //                    !event.getMember().hasPermission(Permission.MANAGE_SERVER)) {
 //                    event.getChannel().sendMessage("❌ You don't have permission to delete commands! You need Administrator or Manage Server permissions.").queue();
 //                    return;
 //                }
 
-                // Parse the command name to delete
-                String commandName = messageContent.trim();
-                
-                if (commandName.isEmpty()) {
-                    event.getChannel().sendMessage("Usage: !delete <command_name>").queue();
+            // Parse the command name to delete
+            String commandName = messageContent.trim();
+
+            if (commandName.isEmpty()) {
+                event.getChannel().sendMessage("Usage: !delete <command_name>").queue();
+                return;
+            }
+
+            try {
+                // Check if the command exists
+                var commandFile = JsonStructureLib.createReader().readFile("commands/" + commandName + ".json");
+                if (commandFile == null) {
+                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
                     return;
                 }
 
-                try {
-                    // Check if the command exists
-                    var commandFile = JsonStructureLib.createReader().readFile("commands/" + commandName + ".json");
-                    if (commandFile == null) {
-                        event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                        return;
-                    }
-
-                    // Verify the command name matches
-                    String actualName = commandFile.getString("name", "");
-                    if (!actualName.equals(commandName)) {
-                        event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                        return;
-                    }
-
-                    // Delete the command file
-                    File fileToDelete = new File("commands/" + commandName + ".json");
-                    if (fileToDelete.exists() && fileToDelete.delete()) {
-                        event.getChannel().sendMessage("✅ Successfully deleted command `" + commandName + "`!").queue();
-                    } else {
-                        event.getChannel().sendMessage("❌ Failed to delete command `" + commandName + "`. Please try again.").queue();
-                    }
-
-                } catch (Exception e) {
-                    event.getChannel().sendMessage("❌ Error deleting command `" + commandName + "`: " + e.getMessage()).queue();
+                // Verify the command name matches
+                String actualName = commandFile.getString("name", "");
+                if (!actualName.equals(commandName)) {
+                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
+                    return;
                 }
-            } else {
-                event.getChannel().sendMessage("Unknown command: " + command).queue();
+
+                // Delete the command file
+                File fileToDelete = new File("commands/" + commandName + ".json");
+                if (fileToDelete.exists() && fileToDelete.delete()) {
+                    CommandCache.invalidateOnUpdate(commandName);
+                    event.getChannel().sendMessage("✅ Successfully deleted command `" + commandName + "`!").queue();
+                } else {
+                    event.getChannel().sendMessage("❌ Failed to delete command `" + commandName + "`. Please try again.").queue();
+                }
+
+            } catch (Exception e) {
+                event.getChannel().sendMessage("❌ Error deleting command `" + commandName + "`: " + e.getMessage()).queue();
             }
+        } else {
+            event.getChannel().sendMessage("Unknown command: " + command).queue();
         }
     }
 }

--- a/src/main/java/nl/finnt730/DeleteCommand.java
+++ b/src/main/java/nl/finnt730/DeleteCommand.java
@@ -1,12 +1,9 @@
 package nl.finnt730;
 
 import haxe.root.JsonStructureLib;
-import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 import java.io.File;
-import java.util.Objects;
 
 public final class DeleteCommand extends ReservedCommand {
 
@@ -34,7 +31,7 @@ public final class DeleteCommand extends ReservedCommand {
 
             try {
                 // Check if the command exists
-                var commandFile = JsonStructureLib.createReader().readFile("commands/" + commandName + ".json");
+                var commandFile = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, commandName));
                 if (commandFile == null) {
                     event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
                     return;
@@ -48,7 +45,7 @@ public final class DeleteCommand extends ReservedCommand {
                 }
 
                 // Delete the command file
-                File fileToDelete = new File("commands/" + commandName + ".json");
+                File fileToDelete = new File(String.format(Global.COMMANDS_LOCATION, commandName));
                 if (fileToDelete.exists() && fileToDelete.delete()) {
                     CommandCache.invalidateOnUpdate(commandName);
                     event.getChannel().sendMessage("✅ Successfully deleted command `" + commandName + "`!").queue();

--- a/src/main/java/nl/finnt730/DeleteCommand.java
+++ b/src/main/java/nl/finnt730/DeleteCommand.java
@@ -1,63 +1,68 @@
 package nl.finnt730;
 
+import haxe.root.Array;
 import haxe.root.JsonStructureLib;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
 import java.io.File;
 
 public final class DeleteCommand extends ReservedCommand {
-
+    private static final String USAGE_HINT = "Usage: !delete <command_name>";
     @Override
     public void handle(MessageReceivedEvent event, String invoker, String commandContents) {
         String rawMessage = event.getMessage().getContentRaw();
         String command = rawMessage.substring(1).split(" ", 2)[0];
         String messageContent = rawMessage.substring(command.length() + 2);
 
-        if (command.equalsIgnoreCase("delete")) {
-            // Check if user has admin or manage server permissions
+        // Check if user has admin or manage server permissions
 //                if (!Objects.requireNonNull(event.getMember()).hasPermission(Permission.ADMINISTRATOR) &&
 //                    !event.getMember().hasPermission(Permission.MANAGE_SERVER)) {
 //                    event.getChannel().sendMessage("❌ You don't have permission to delete commands! You need Administrator or Manage Server permissions.").queue();
 //                    return;
 //                }
 
-            // Parse the command name to delete
-            String commandName = messageContent.trim();
+        // Parse the command name to delete
+        String commandName = messageContent.trim();
 
-            if (commandName.isEmpty()) {
-                event.getChannel().sendMessage("Usage: !delete <command_name>").queue();
+        if (commandName.isEmpty()) {
+            event.getChannel().sendMessage(USAGE_HINT).queue();
+            return;
+        }
+
+        try {
+            // Check if the command exists
+            var commandFile = JsonStructureLib.createReader().readFile(Global.commandOf(commandName));
+            if (commandFile == null) {
+                event.getChannel().sendMessage("Command `" + commandName + "` not found!").queue();
                 return;
             }
 
-            try {
-                // Check if the command exists
-                var commandFile = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, commandName));
-                if (commandFile == null) {
-                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                    return;
-                }
-
-                // Verify the command name matches
-                String actualName = commandFile.getString("name", "");
-                if (!actualName.equals(commandName)) {
-                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                    return;
-                }
-
-                // Delete the command file
-                File fileToDelete = new File(String.format(Global.COMMANDS_LOCATION, commandName));
-                if (fileToDelete.exists() && fileToDelete.delete()) {
-                    CommandCache.invalidateOnUpdate(commandName);
-                    event.getChannel().sendMessage("✅ Successfully deleted command `" + commandName + "`!").queue();
-                } else {
-                    event.getChannel().sendMessage("❌ Failed to delete command `" + commandName + "`. Please try again.").queue();
-                }
-
-            } catch (Exception e) {
-                event.getChannel().sendMessage("❌ Error deleting command `" + commandName + "`: " + e.getMessage()).queue();
+            // Verify the command name matches
+            String actualName = commandFile.getString("name", "");
+            if (!actualName.equals(commandName)) {
+                event.getChannel().sendMessage("Command `" + commandName + "` not found!").queue();
+                return;
             }
-        } else {
-            event.getChannel().sendMessage("Unknown command: " + command).queue();
+
+            // Delete the command file
+            File fileToDelete = new File(Global.commandOf(commandName));
+            if (fileToDelete.exists()) {
+                var arr = (Array<String>)JsonStructureLib.createReader().readFile(Global.commandOf(commandName)).getArray("aliases");
+                var iter = arr.iterator();
+                while (iter.hasNext()) {
+                    CommandCache.invalidateOnUpdate(iter.next());
+                }
+                CommandCache.invalidateOnUpdate(commandName);
+                if (fileToDelete.delete()) {
+
+                    event.getChannel().sendMessage("Successfully deleted command `" + commandName + "`!").queue();
+                } else {
+                    event.getChannel().sendMessage("Failed to delete command `" + commandName + "`. Please try again.").queue();
+                }
+            }
+
+        } catch (Exception e) {
+            event.getChannel().sendMessage("Error deleting command `" + commandName + "`: " + e.getMessage()).queue();
         }
     }
 }

--- a/src/main/java/nl/finnt730/DescriptionCommand.java
+++ b/src/main/java/nl/finnt730/DescriptionCommand.java
@@ -3,7 +3,6 @@ package nl.finnt730;
 import haxe.root.JsonStructureLib;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 import java.util.Objects;
 
@@ -36,7 +35,7 @@ public final class DescriptionCommand extends ReservedCommand {
 
             try {
                 // Check if the command exists
-                var commandFile = JsonStructureLib.createReader().readFile("commands/" + commandName + ".json");
+                var commandFile = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, commandName));
                 if (commandFile == null) {
                     event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
                     return;
@@ -64,7 +63,7 @@ public final class DescriptionCommand extends ReservedCommand {
                         .build();
 
                 // Write the updated command back to file
-                JsonStructureLib.writeJsonFile(updatedCommandObject, "commands/" + commandName + ".json", Global.COMMAND_STRUCTURE);
+                JsonStructureLib.writeJsonFile(updatedCommandObject, String.format(Global.COMMANDS_LOCATION, commandName), Global.COMMAND_STRUCTURE);
 
                 event.getChannel().sendMessage("✅ Successfully updated description for command `" + commandName + "`!\n" +
                         "**Old description:** " + oldDescription + "\n" +

--- a/src/main/java/nl/finnt730/DescriptionCommand.java
+++ b/src/main/java/nl/finnt730/DescriptionCommand.java
@@ -7,73 +7,63 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import java.util.Objects;
 
 public final class DescriptionCommand extends ReservedCommand {
+    private static final String USAGE_HINT = "Usage: !description <command_name> \"<new_description>\"";
 
     @Override
     public void handle(MessageReceivedEvent event, String invoker, String additionalData) {
-        String rawMessage = event.getMessage().getContentRaw();
-        String command = rawMessage.substring(1).split(" ", 2)[0];
-        String messageContent = rawMessage.substring(command.length() + 2);
-
-        if (command.equalsIgnoreCase("description")) {
-            // Check if user has admin or manage server permissions
-            if (!Objects.requireNonNull(event.getMember()).hasPermission(Permission.ADMINISTRATOR) &&
-                !event.getMember().hasPermission(Permission.MANAGE_SERVER)) {
-                event.getChannel().sendMessage("❌ You don't have permission to modify command descriptions! You need Administrator or Manage Server permissions.").queue();
-                return;
-            }
-
-            // Parse the message content properly to handle quoted strings
-            String[] parsedArgs = Global.parseQuotedString(messageContent);
-
-            if (parsedArgs.length < 2) {
-                event.getChannel().sendMessage("Usage: !description <command_name> \"<new_description>\"").queue();
-                return;
-            }
-
-            String commandName = parsedArgs[0];
-            String newDescription = parsedArgs[1];
-
-            try {
-                // Check if the command exists
-                var commandFile = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, commandName));
-                if (commandFile == null) {
-                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                    return;
-                }
-
-                // Verify the command name matches
-                String actualName = commandFile.getString("name", "");
-                if (!actualName.equals(commandName)) {
-                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                    return;
-                }
-
-                // Get the old description for confirmation
-                String oldDescription = commandFile.getString("description", "No description");
-                String data = commandFile.getString("data", "");
-                var aliases = commandFile.getStringArray("aliases");
-
-                // Create updated command object
-                var builder = JsonStructureLib.createObjectBuilder();
-                var updatedCommandObject = builder
-                        .addStringField("name", commandName)
-                        .addStringField("description", newDescription)
-                        .addStringField("data", data)
-                        .addStringArrayField("aliases", aliases)
-                        .build();
-
-                // Write the updated command back to file
-                JsonStructureLib.writeJsonFile(updatedCommandObject, String.format(Global.COMMANDS_LOCATION, commandName), Global.COMMAND_STRUCTURE);
-
-                event.getChannel().sendMessage("✅ Successfully updated description for command `" + commandName + "`!\n" +
-                        "**Old description:** " + oldDescription + "\n" +
-                        "**New description:** " + newDescription).queue();
-
-            } catch (Exception e) {
-                event.getChannel().sendMessage("❌ Error updating description for command `" + commandName + "`: " + e.getMessage()).queue();
-            }
-        } else {
-            event.getChannel().sendMessage("Unknown command: " + command).queue();
+        String[] split = additionalData.split(" ", 2);
+        if (split.length < 2) {
+            event.getChannel().sendMessage(USAGE_HINT).queue();
+            return;
         }
+        String command = split[0];
+        String messageContent = split[1];
+        // Check if user has admin or manage server permissions
+        if (!Objects.requireNonNull(event.getMember()).hasPermission(Permission.ADMINISTRATOR) &&
+            !event.getMember().hasPermission(Permission.MANAGE_SERVER)) {
+            event.getChannel().sendMessage("You don't have permission to modify command descriptions! You need Administrator or Manage Server permissions.").queue();
+            return;
+        }
+
+        try {
+            // Check if the command exists
+            var commandFile = JsonStructureLib.createReader().readFile(Global.commandOf(command));
+            if (commandFile == null) {
+                event.getChannel().sendMessage("Command `" + command + "` not found!").queue();
+                return;
+            }
+
+            // Verify the command name matches
+            String actualName = commandFile.getString("name", "");
+            if (!actualName.equals(command)) {
+                event.getChannel().sendMessage("Command `" + command + "` not found!").queue();
+                return;
+            }
+
+            // Get the old description for confirmation
+            String oldDescription = commandFile.getString("description", "No description");
+            String data = commandFile.getString("data", "");
+            var aliases = commandFile.getStringArray("aliases");
+
+            // Create updated command object
+            var builder = JsonStructureLib.createObjectBuilder();
+            var updatedCommandObject = builder
+                    .addStringField("name", command)
+                    .addStringField("description", messageContent)
+                    .addStringField("data", data)
+                    .addStringArrayField("aliases", aliases)
+                    .build();
+
+            // Write the updated command back to file
+            JsonStructureLib.writeJsonFile(updatedCommandObject, Global.commandOf(command), Global.COMMAND_STRUCTURE);
+
+            event.getChannel().sendMessage("Updated description for `" + command + "`!\n" +
+                    "**Old description:** " + oldDescription + "\n" +
+                    "**New description:** " + messageContent).queue();
+
+        } catch (Exception e) {
+            event.getChannel().sendMessage("Error updating description for `" + command + "`: " + e.getMessage()).queue();
+        }
+
     }
 }

--- a/src/main/java/nl/finnt730/DescriptionCommand.java
+++ b/src/main/java/nl/finnt730/DescriptionCommand.java
@@ -7,76 +7,74 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 import java.util.Objects;
 
-public final class DescriptionCommand extends ListenerAdapter {
+public final class DescriptionCommand extends ReservedCommand {
 
     @Override
-    public void onMessageReceived(MessageReceivedEvent event) {
+    public void handle(MessageReceivedEvent event, String invoker, String additionalData) {
         String rawMessage = event.getMessage().getContentRaw();
-        if (rawMessage.startsWith("!description")) {
-            String command = rawMessage.substring(1).split(" ", 2)[0];
-            String messageContent = rawMessage.substring(command.length() + 2);
+        String command = rawMessage.substring(1).split(" ", 2)[0];
+        String messageContent = rawMessage.substring(command.length() + 2);
 
-            if (command.equalsIgnoreCase("description")) {
-                // Check if user has admin or manage server permissions
-                if (!Objects.requireNonNull(event.getMember()).hasPermission(Permission.ADMINISTRATOR) &&
-                    !event.getMember().hasPermission(Permission.MANAGE_SERVER)) {
-                    event.getChannel().sendMessage("❌ You don't have permission to modify command descriptions! You need Administrator or Manage Server permissions.").queue();
-                    return;
-                }
-
-                // Parse the message content properly to handle quoted strings
-                String[] parsedArgs = Global.parseQuotedString(messageContent);
-                
-                if (parsedArgs.length < 2) {
-                    event.getChannel().sendMessage("Usage: !description <command_name> \"<new_description>\"").queue();
-                    return;
-                }
-                
-                String commandName = parsedArgs[0];
-                String newDescription = parsedArgs[1];
-
-                try {
-                    // Check if the command exists
-                    var commandFile = JsonStructureLib.createReader().readFile("commands/" + commandName + ".json");
-                    if (commandFile == null) {
-                        event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                        return;
-                    }
-
-                    // Verify the command name matches
-                    String actualName = commandFile.getString("name", "");
-                    if (!actualName.equals(commandName)) {
-                        event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
-                        return;
-                    }
-
-                    // Get the old description for confirmation
-                    String oldDescription = commandFile.getString("description", "No description");
-                    String data = commandFile.getString("data", "");
-                    var aliases = commandFile.getStringArray("aliases");
-
-                    // Create updated command object
-                    var builder = JsonStructureLib.createObjectBuilder();
-                    var updatedCommandObject = builder
-                            .addStringField("name", commandName)
-                            .addStringField("description", newDescription)
-                            .addStringField("data", data)
-                            .addStringArrayField("aliases", aliases)
-                            .build();
-
-                    // Write the updated command back to file
-                    JsonStructureLib.writeJsonFile(updatedCommandObject, "commands/" + commandName + ".json", Global.COMMAND_STRUCTURE);
-
-                    event.getChannel().sendMessage("✅ Successfully updated description for command `" + commandName + "`!\n" +
-                            "**Old description:** " + oldDescription + "\n" +
-                            "**New description:** " + newDescription).queue();
-
-                } catch (Exception e) {
-                    event.getChannel().sendMessage("❌ Error updating description for command `" + commandName + "`: " + e.getMessage()).queue();
-                }
-            } else {
-                event.getChannel().sendMessage("Unknown command: " + command).queue();
+        if (command.equalsIgnoreCase("description")) {
+            // Check if user has admin or manage server permissions
+            if (!Objects.requireNonNull(event.getMember()).hasPermission(Permission.ADMINISTRATOR) &&
+                !event.getMember().hasPermission(Permission.MANAGE_SERVER)) {
+                event.getChannel().sendMessage("❌ You don't have permission to modify command descriptions! You need Administrator or Manage Server permissions.").queue();
+                return;
             }
+
+            // Parse the message content properly to handle quoted strings
+            String[] parsedArgs = Global.parseQuotedString(messageContent);
+
+            if (parsedArgs.length < 2) {
+                event.getChannel().sendMessage("Usage: !description <command_name> \"<new_description>\"").queue();
+                return;
+            }
+
+            String commandName = parsedArgs[0];
+            String newDescription = parsedArgs[1];
+
+            try {
+                // Check if the command exists
+                var commandFile = JsonStructureLib.createReader().readFile("commands/" + commandName + ".json");
+                if (commandFile == null) {
+                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
+                    return;
+                }
+
+                // Verify the command name matches
+                String actualName = commandFile.getString("name", "");
+                if (!actualName.equals(commandName)) {
+                    event.getChannel().sendMessage("❌ Command `" + commandName + "` not found!").queue();
+                    return;
+                }
+
+                // Get the old description for confirmation
+                String oldDescription = commandFile.getString("description", "No description");
+                String data = commandFile.getString("data", "");
+                var aliases = commandFile.getStringArray("aliases");
+
+                // Create updated command object
+                var builder = JsonStructureLib.createObjectBuilder();
+                var updatedCommandObject = builder
+                        .addStringField("name", commandName)
+                        .addStringField("description", newDescription)
+                        .addStringField("data", data)
+                        .addStringArrayField("aliases", aliases)
+                        .build();
+
+                // Write the updated command back to file
+                JsonStructureLib.writeJsonFile(updatedCommandObject, "commands/" + commandName + ".json", Global.COMMAND_STRUCTURE);
+
+                event.getChannel().sendMessage("✅ Successfully updated description for command `" + commandName + "`!\n" +
+                        "**Old description:** " + oldDescription + "\n" +
+                        "**New description:** " + newDescription).queue();
+
+            } catch (Exception e) {
+                event.getChannel().sendMessage("❌ Error updating description for command `" + commandName + "`: " + e.getMessage()).queue();
+            }
+        } else {
+            event.getChannel().sendMessage("Unknown command: " + command).queue();
         }
     }
 }

--- a/src/main/java/nl/finnt730/EchoCommand.java
+++ b/src/main/java/nl/finnt730/EchoCommand.java
@@ -1,0 +1,13 @@
+package nl.finnt730;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+public class EchoCommand extends Command {
+    private final String echo;
+    public EchoCommand(String echo) { this.echo = echo;}
+
+    @Override
+    public void handle(MessageReceivedEvent event, String invoker, String commandContents) {
+        event.getChannel().sendMessage(echo).queue();
+    }
+}

--- a/src/main/java/nl/finnt730/ExecuteCommand.java
+++ b/src/main/java/nl/finnt730/ExecuteCommand.java
@@ -11,46 +11,18 @@ public final class ExecuteCommand extends ListenerAdapter {
 
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
+        if (event.getAuthor().isBot()) return; // Strictly ignore any bot messages.
         String rawMessage = event.getMessage().getContentRaw();
-
-        // Check if the message starts with "!"
-        if (rawMessage.isEmpty() || rawMessage.charAt(0) != '!')
-            return;
-
-        String commandName = rawMessage.substring(1).split(" ", 2)[0];
-        if (RESERVED_COMMANDS.contains(commandName))
-            return;
-
-        try {
-            var command = JsonStructureLib.createReader().readFile("commands/" + commandName + ".json");
-            if (command != null && command.getString("name", "_null").equals(commandName)) {
-                String data = command.getString("data", "");
-                event.getChannel().sendMessage(data).queue();
-                return;
-            }
-        } catch (Exception e) {
-            // Ignore the exception, it means the file does not exist
+        if (rawMessage.isEmpty()) return;
+        String author = event.getAuthor().getName();
+        var context = CommandCache.getOrDefault(event.getAuthor().getName(), rawMessage);
+        if (context == CommandContext.NONE) {
+            return; // Was not a command
+        } else if (context == CommandContext.NOT_FOUND) {
+            event.getChannel().sendMessage("Command not found!").queue();
+        } else {
+            context.command().handle(event, author, context.additionalData());
         }
-
-        try {
-            // If not found, check aliases
-            var files = new java.io.File("commands").listFiles((dir, name) -> name.endsWith(".json"));
-            if (files != null) {
-                for (var file : files) {
-                    var cmd = JsonStructureLib.createReader().readFile(file.getPath());
-                    var aliases = cmd.getStringArray("aliases");
-                    if (aliases.contains(commandName)) {
-                        String data = cmd.getString("data", "");
-                        event.getChannel().sendMessage(data).queue();
-                        return;
-                    }
-                }
-            }
-        } catch (Exception e) {
-            // Ignore the exception
-        }
-
-        event.getChannel().sendMessage("Command not found!").queue();
 
 //        var command = JsonStructureLib.createReader().readFile("commands/" + event.getMessage().getContentRaw().substring(1).split(" ")[0] + ".json");
 //        if (command == null) {

--- a/src/main/java/nl/finnt730/ExecuteCommand.java
+++ b/src/main/java/nl/finnt730/ExecuteCommand.java
@@ -1,6 +1,5 @@
 package nl.finnt730;
 
-import haxe.root.JsonStructureLib;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
@@ -15,13 +14,15 @@ public final class ExecuteCommand extends ListenerAdapter {
         String rawMessage = event.getMessage().getContentRaw();
         if (rawMessage.isEmpty()) return;
         String author = event.getAuthor().getName();
-        var context = CommandCache.getOrDefault(event.getAuthor().getName(), rawMessage);
+        boolean silent = rawMessage.startsWith("s") || rawMessage.startsWith("S");
+        var context = CommandCache.getOrDefault(event.getAuthor().getName(), silent ? rawMessage.substring(1) : rawMessage);
         if (context == CommandContext.NONE) {
             return; // Was not a command
         } else if (context == CommandContext.NOT_FOUND) {
             event.getChannel().sendMessage("Command not found!").queue();
         } else {
             context.command().handle(event, author, context.additionalData());
+            if (silent) event.getMessage().delete().queue();
         }
 
 //        var command = JsonStructureLib.createReader().readFile("commands/" + event.getMessage().getContentRaw().substring(1).split(" ")[0] + ".json");

--- a/src/main/java/nl/finnt730/Global.java
+++ b/src/main/java/nl/finnt730/Global.java
@@ -6,7 +6,7 @@ import haxe.root.JsonStructureLib;
 import java.util.ArrayList;
 
 public final class Global {
-    public static final String COMMANDS_LOCATION = "commands/%s.json";
+    private static final String COMMANDS_LOCATION = "commands/%s.json";
     private Global() {}
 
     public static final JsonStructure COMMAND_STRUCTURE = JsonStructureLib.createStructure()
@@ -62,5 +62,9 @@ public final class Global {
         }
 
         return result.toArray(new String[0]);
+    }
+
+    public static String commandOf(String cmdName) {
+        return String.format(COMMANDS_LOCATION, cmdName);
     }
 }

--- a/src/main/java/nl/finnt730/Global.java
+++ b/src/main/java/nl/finnt730/Global.java
@@ -6,6 +6,7 @@ import haxe.root.JsonStructureLib;
 import java.util.ArrayList;
 
 public final class Global {
+    public static final String COMMANDS_LOCATION = "commands/%s.json";
     private Global() {}
 
     public static final JsonStructure COMMAND_STRUCTURE = JsonStructureLib.createStructure()

--- a/src/main/java/nl/finnt730/Main.java
+++ b/src/main/java/nl/finnt730/Main.java
@@ -20,11 +20,7 @@ public final class Main {
             String botToken = json.getString("botToken", "");
 
             JDABuilder.createLight(botToken, EnumSet.of(GatewayIntent.GUILD_MESSAGES, GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MESSAGE_POLLS, GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_MESSAGE_REACTIONS))
-                    .addEventListeners(new RegisterNewCommand())
                     .addEventListeners(new ExecuteCommand())
-                    .addEventListeners(new AliasCommand())
-                    .addEventListeners(new DeleteCommand())
-                    .addEventListeners(new DescriptionCommand())
                     .addEventListeners(new PasteCommand())
                     .build();
         } catch (Exception e) {

--- a/src/main/java/nl/finnt730/RegisterNewCommand.java
+++ b/src/main/java/nl/finnt730/RegisterNewCommand.java
@@ -16,13 +16,13 @@ public final class RegisterNewCommand extends ReservedCommand {
             return;
         }
         String command = split[0];
-        String description = split[1].replace("\"", "");
+        String description = split[1];
         // Parse the message content properly to handle quoted strings
         String[] parsedArgs = Global.parseQuotedString(description);
 
-        String data = parsedArgs[1];
-        description = parsedArgs.length > 2 ? parsedArgs[2] : "No description provided";
-        String[] aliases = parsedArgs.length > 3 ? parsedArgs[3].split(",") : new String[0];
+        String data = parsedArgs[0];
+        description = parsedArgs.length > 1 ? parsedArgs[1] : "No description provided";
+        String[] aliases = parsedArgs.length > 2 ? parsedArgs[2].split(",") : new String[0];
 //                StringBuilder options = new StringBuilder();
 //                for (int i = 4; i < args.length; i++) {
 //                    options.append(args[i]).append(" ");
@@ -30,7 +30,7 @@ public final class RegisterNewCommand extends ReservedCommand {
 //                String optionsString = options.toString().trim();
 
         try {
-            DynamicJson json_exists = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, command));
+            DynamicJson json_exists = JsonStructureLib.createReader().readFile(Global.commandOf(command));
             if(json_exists != null) {
                 event.getChannel().sendMessage("Command with name " + command + " already exists!").queue();
                 return;
@@ -56,7 +56,7 @@ public final class RegisterNewCommand extends ReservedCommand {
 //                        .addStringField("options", optionsString)
                 .build();
 
-        JsonStructureLib.writeJsonFile(commandObject, String.format(Global.COMMANDS_LOCATION, command), Global.COMMAND_STRUCTURE);
+        JsonStructureLib.writeJsonFile(commandObject, Global.commandOf(command), Global.COMMAND_STRUCTURE);
         event.getChannel().sendMessage("Command has been registered!").queue();
     }
 }

--- a/src/main/java/nl/finnt730/RegisterNewCommand.java
+++ b/src/main/java/nl/finnt730/RegisterNewCommand.java
@@ -6,69 +6,68 @@ import haxe.root.JsonStructureLib;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
-public final class RegisterNewCommand extends ListenerAdapter  {
+public final class RegisterNewCommand extends ReservedCommand {
+    private static final String USAGE_HINT = "Usage: !register <name> \"<data>\" [description] [aliases]";
 
     @Override
-    public void onMessageReceived(MessageReceivedEvent event) {
-        if(event.getMessage().getContentRaw().startsWith("!register")) {
-            String command = event.getMessage().getContentRaw().substring(1).split(" ", 2)[0];
-            String messageContent = event.getMessage().getContentRaw().substring(command.length() + 2);
+    public void handle(MessageReceivedEvent event, String invoker, String commandContents) {
+        String command = event.getMessage().getContentRaw().substring(1).split(" ", 2)[0];
+        String messageContent = event.getMessage().getContentRaw().substring(command.length() + 2);
 
-            System.out.println(command);
-            System.out.println("Message content: " + messageContent);
+        System.out.println(command);
+        System.out.println("Message content: " + messageContent);
 
-            if (command.equalsIgnoreCase("register")) {
-                // Parse the message content properly to handle quoted strings
-                String[] parsedArgs = Global.parseQuotedString(messageContent);
-                
-                if (parsedArgs.length < 2) {
-                    event.getChannel().sendMessage("Usage: !register <name> \"<data>\" [description] [aliases]").queue();
-                    return;
-                }
-                
-                String name = parsedArgs[0];
-                String data = parsedArgs[1];
-                String description = parsedArgs.length > 2 ? parsedArgs[2] : "No description provided";
-                String[] aliases = parsedArgs.length > 3 ? parsedArgs[3].split(",") : new String[0];
+        if (command.equalsIgnoreCase("register")) {
+            // Parse the message content properly to handle quoted strings
+            String[] parsedArgs = Global.parseQuotedString(messageContent);
+
+            if (parsedArgs.length < 2) {
+                event.getChannel().sendMessage(USAGE_HINT).queue();
+                return;
+            }
+
+            String name = parsedArgs[0];
+            String data = parsedArgs[1];
+            String description = parsedArgs.length > 2 ? parsedArgs[2] : "No description provided";
+            String[] aliases = parsedArgs.length > 3 ? parsedArgs[3].split(",") : new String[0];
 //                StringBuilder options = new StringBuilder();
 //                for (int i = 4; i < args.length; i++) {
 //                    options.append(args[i]).append(" ");
 //                }
 //                String optionsString = options.toString().trim();
 
-                try {
-                    DynamicJson json_exists = JsonStructureLib.createReader().readFile(name + ".json");
-                    if(json_exists != null) {
-                        event.getChannel().sendMessage("Command with name " + name + " already exists!").queue();
-                        return;
-                    }
-                } catch (Exception e) {
-                    // Ignore the exception, it means the file does not exist
+            try {
+                DynamicJson json_exists = JsonStructureLib.createReader().readFile(name + ".json");
+                if(json_exists != null) {
+                    event.getChannel().sendMessage("Command with name " + name + " already exists!").queue();
+                    return;
                 }
-
-
-                Array<String> _aliases = new Array<>();
-                for (String alias : aliases) {
-                    if (!alias.isEmpty()) {
-                        _aliases.push(alias.trim());
-                    }
-                }
-
-                var builder = JsonStructureLib.createObjectBuilder();
-                var commandObject = builder
-                        .addStringField("name", name)
-                        .addStringField("description", description)
-                        .addStringField("data", data)
-                        .addStringArrayField("aliases", _aliases)
-//                        .addStringField("options", optionsString)
-                        .build();
-
-                JsonStructureLib.writeJsonFile(commandObject, "commands/" + name + ".json", Global.COMMAND_STRUCTURE);
-                event.getChannel().sendMessage("command has been registered!").queue();
-
-            } else {
-                event.getChannel().sendMessage("Unknown command: " + command).queue();
+            } catch (Exception e) {
+                // Ignore the exception, it means the file does not exist
             }
+
+
+            Array<String> _aliases = new Array<>();
+            for (String alias : aliases) {
+                if (!alias.isEmpty()) {
+                    _aliases.push(alias.trim());
+                }
+            }
+
+            var builder = JsonStructureLib.createObjectBuilder();
+            var commandObject = builder
+                    .addStringField("name", name)
+                    .addStringField("description", description)
+                    .addStringField("data", data)
+                    .addStringArrayField("aliases", _aliases)
+//                        .addStringField("options", optionsString)
+                    .build();
+
+            JsonStructureLib.writeJsonFile(commandObject, "commands/" + name + ".json", Global.COMMAND_STRUCTURE);
+            event.getChannel().sendMessage("command has been registered!").queue();
+
+        } else {
+            event.getChannel().sendMessage("Unknown command: " + command).queue();
         }
     }
 }

--- a/src/main/java/nl/finnt730/RegisterNewCommand.java
+++ b/src/main/java/nl/finnt730/RegisterNewCommand.java
@@ -4,70 +4,59 @@ import com.jsonstructure.DynamicJson;
 import haxe.root.Array;
 import haxe.root.JsonStructureLib;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
-import net.dv8tion.jda.api.hooks.ListenerAdapter;
 
 public final class RegisterNewCommand extends ReservedCommand {
     private static final String USAGE_HINT = "Usage: !register <name> \"<data>\" [description] [aliases]";
 
     @Override
     public void handle(MessageReceivedEvent event, String invoker, String commandContents) {
-        String command = event.getMessage().getContentRaw().substring(1).split(" ", 2)[0];
-        String messageContent = event.getMessage().getContentRaw().substring(command.length() + 2);
+        String[] split = commandContents.split(" ", 2);
+        if (split.length < 2) {
+            event.getChannel().sendMessage(USAGE_HINT).queue();
+            return;
+        }
+        String command = split[0];
+        String description = split[1].replace("\"", "");
+        // Parse the message content properly to handle quoted strings
+        String[] parsedArgs = Global.parseQuotedString(description);
 
-        System.out.println(command);
-        System.out.println("Message content: " + messageContent);
-
-        if (command.equalsIgnoreCase("register")) {
-            // Parse the message content properly to handle quoted strings
-            String[] parsedArgs = Global.parseQuotedString(messageContent);
-
-            if (parsedArgs.length < 2) {
-                event.getChannel().sendMessage(USAGE_HINT).queue();
-                return;
-            }
-
-            String name = parsedArgs[0];
-            String data = parsedArgs[1];
-            String description = parsedArgs.length > 2 ? parsedArgs[2] : "No description provided";
-            String[] aliases = parsedArgs.length > 3 ? parsedArgs[3].split(",") : new String[0];
+        String data = parsedArgs[1];
+        description = parsedArgs.length > 2 ? parsedArgs[2] : "No description provided";
+        String[] aliases = parsedArgs.length > 3 ? parsedArgs[3].split(",") : new String[0];
 //                StringBuilder options = new StringBuilder();
 //                for (int i = 4; i < args.length; i++) {
 //                    options.append(args[i]).append(" ");
 //                }
 //                String optionsString = options.toString().trim();
 
-            try {
-                DynamicJson json_exists = JsonStructureLib.createReader().readFile(name + ".json");
-                if(json_exists != null) {
-                    event.getChannel().sendMessage("Command with name " + name + " already exists!").queue();
-                    return;
-                }
-            } catch (Exception e) {
-                // Ignore the exception, it means the file does not exist
+        try {
+            DynamicJson json_exists = JsonStructureLib.createReader().readFile(String.format(Global.COMMANDS_LOCATION, command));
+            if(json_exists != null) {
+                event.getChannel().sendMessage("Command with name " + command + " already exists!").queue();
+                return;
             }
-
-
-            Array<String> _aliases = new Array<>();
-            for (String alias : aliases) {
-                if (!alias.isEmpty()) {
-                    _aliases.push(alias.trim());
-                }
-            }
-
-            var builder = JsonStructureLib.createObjectBuilder();
-            var commandObject = builder
-                    .addStringField("name", name)
-                    .addStringField("description", description)
-                    .addStringField("data", data)
-                    .addStringArrayField("aliases", _aliases)
-//                        .addStringField("options", optionsString)
-                    .build();
-
-            JsonStructureLib.writeJsonFile(commandObject, "commands/" + name + ".json", Global.COMMAND_STRUCTURE);
-            event.getChannel().sendMessage("command has been registered!").queue();
-
-        } else {
-            event.getChannel().sendMessage("Unknown command: " + command).queue();
+        } catch (Exception e) {
+            // Ignore the exception, it means the file does not exist
         }
+
+
+        Array<String> _aliases = new Array<>();
+        for (String alias : aliases) {
+            if (!alias.isEmpty()) {
+                _aliases.push(alias.trim());
+            }
+        }
+
+        var builder = JsonStructureLib.createObjectBuilder();
+        var commandObject = builder
+                .addStringField("name", command)
+                .addStringField("description", description)
+                .addStringField("data", data)
+                .addStringArrayField("aliases", _aliases)
+//                        .addStringField("options", optionsString)
+                .build();
+
+        JsonStructureLib.writeJsonFile(commandObject, String.format(Global.COMMANDS_LOCATION, command), Global.COMMAND_STRUCTURE);
+        event.getChannel().sendMessage("Command has been registered!").queue();
     }
 }

--- a/src/main/java/nl/finnt730/ReservedCommand.java
+++ b/src/main/java/nl/finnt730/ReservedCommand.java
@@ -1,0 +1,10 @@
+package nl.finnt730;
+
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+
+import java.util.function.Consumer;
+
+public abstract class ReservedCommand extends Command {
+    public ReservedCommand() {
+    }
+}


### PR DESCRIPTION
* Rewrote command system, now ensures command invocation results are cached, reducing IO.
* Removed a LOT of LLM vomit and reduced parsing complexity
* Only one listener, delegates to the CommandCache to determine if something is a command or not
* Added silent commands, trigger of [sS]!. Command parsing will ignore the silent pre-prefix.
* Other cleanup